### PR TITLE
Proving grounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,10 @@ features = ["derive"]
 
 [profile.release]
 debug = true
+lto = "fat"
+codegen-units = 1
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+        "-C", "target-cpu=native",
+]

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,10 +14,10 @@ pub type WaveT = u64;
 pub type WellT = [RowT; EFF_HEIGHT];
 pub type ScoreT = u16;
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Savefile)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Savefile)]
 pub struct State {
-	pub well: WellT,
 	pub score: ScoreT,
+	pub well: WellT,
 } 
 
 impl State {
@@ -27,30 +27,6 @@ impl State {
 
 	pub fn convert(state: StateH) -> State {
 		return State{well: state.well, score: state.score}
-	}
-}
-
-impl Ord for State {
-	fn cmp(&self, other: &Self) -> Ordering {
-		let first_cmp = self.score.cmp(&other.score);
-		if first_cmp != Ordering::Equal {
-			return first_cmp
-		}
-
-		let mut second_cmp = Ordering::Equal;
-		let mut i = 0;
-		while second_cmp == Ordering::Equal && i < EFF_HEIGHT {
-			second_cmp = self.well[i].cmp(&other.well[i]);
-			i += 1;
-		}
-
-		return second_cmp
-	}
-}
-
-impl PartialOrd for State {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		Some(self.cmp(other))
 	}
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,11 +2,11 @@
 
 use crate::constants::{AEON, ALL_CONV, CHECKPOINTS, EFF_HEIGHT, HIDDEN, TRAINING_BEAM_WIDTH, TRAINING_BEAM_DEPTH, MASTER_BEAM_WIDTH, MULTIPLIER};
 
-use std::{cmp::{Ordering}};
+use std::cmp::{Ordering};
 //use std::{arch::x86_64::__m256d, simd::f64x4};
 
 use savefile::prelude::Savefile;
-use rand::{thread_rng};
+use rand::thread_rng;
 use rand_distr::{Distribution, Normal};
 
 pub type RowT = u16;
@@ -54,57 +54,11 @@ impl PartialOrd for State {
 	}
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StateH {
-	pub well: WellT,
-	pub score: ScoreT,
-	pub heuristic: i64
-} 
-
-impl PartialEq for StateH {
-	fn eq(&self, other: &Self) -> bool {
-		if self.score != self.score {
-			return false
-		} else {
-			for i in 0..EFF_HEIGHT {
-				if self.well[i] != other.well[i] {
-					return false
-				}
-			}
-		}
-		return true
-	}
-}
-
-impl Eq for StateH {}
-
-impl Ord for StateH {
-	fn cmp(&self, other: &Self) -> Ordering {
-		let first_cmp = self.heuristic.cmp(&other.heuristic);
-		if first_cmp != Ordering::Equal {
-			return first_cmp
-		}
-
-		let second_cmp = self.score.cmp(&other.score);
-		if second_cmp != Ordering::Equal {
-			return second_cmp
-		}
-
-		let mut third_cmp = Ordering::Equal;
-		let mut i = 0;
-		while third_cmp == Ordering::Equal && i < EFF_HEIGHT {
-			third_cmp = self.well[i].cmp(&other.well[i]);
-			i += 1;
-		}
-
-		return third_cmp
-	}
-}
-
-impl PartialOrd for StateH {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		Some(self.cmp(other))
-	}
+    pub heuristic: i64,
+    pub score: ScoreT,
+    pub well: WellT,
 }
 
 impl StateH {


### PR DESCRIPTION
closes https://github.com/thecog19/HATETRIS-public-beamsearch/issues/1

Based on @SandaruKasa's informative issue request, we've implemented most but not all of the proposed changes.

The manual `Eq` and `PartialOrd` implementations were from an earlier point in development, when 'heuristic' was stored as `f64` and `Eq` and `Ord` (and related traits) were not automatically derivable.  We also didn't know about the field ordering changing the order of evaluation, and were trying to short-circuit and save time by specifying the fields by hand.  Now that `heuristic` is 'i64`, however, this simplifies that whole part of the code significantly; we did the same thing for `State`, though we're not sure `State` ever actually calls `Ord`, just to be thorough.

The various compiler optimizations make sense; we are happy to sacrifice some small amount of compile time for even small gains in code performance, since the usual use case of this code involves running it for multiple days.  The only suggestion we did not implement was the preventing of stack unwinding:

```rust
[profile.release]
panic = "abort"

Given how long this code typically runs for, if there _is_ an issue that only occurs far into a run, recreating that issue will be a pain, and having the option for stack printing (along with the debug symbol table, and we typically run this with `RUST_BACKTRACE=full`) potentially saves us a lot of pain while debugging.