### PR TITLE
Move rustflags to the correct config file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+        "-C", "target-cpu=native",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,3 @@ features = ["derive"]
 debug = true
 lto = "fat"
 codegen-units = 1
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-        "-C", "target-cpu=native",
-]


### PR DESCRIPTION
Rust's / Cargo's hierarchy of configuration files _is_ kinda convoluted, not gonna lie.